### PR TITLE
Add a link to the triage policy documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       triage owners. Add bugs you're not sure what to do with to
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=webrtc-triage" target="_new">webrtc-triage</a>
       or <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=webrtc-triage" target="_new">media-triage</a> for
-      team triage.
+      team triage. See the <a href="https://firefox-source-docs.mozilla.org/bug-mgmt/policies/triage-bugzilla.html" target="_new">Mozilla Triage for Bugzilla</a> documentation for details on the triage process.
     </div>
   </div>
   <center><div id="content"><h2>No triage information for this year</h2></div></center>


### PR DESCRIPTION
This adds a link to the triage policy documentation.