### PR TITLE
feat: add tooltips to bug list links

### DIFF
--- a/css/triage.css
+++ b/css/triage.css
@@ -129,6 +129,7 @@ a:hover {
   font-size: 1vw;
   display: inline-block;
   color: #000000;
+  cursor: help;
 }
 
 #errors {

--- a/js/triage.js
+++ b/js/triage.js
@@ -341,7 +341,7 @@ function updateBugList(divId, divIndex, totalBugs, searchUrl) {
     return;
   }
 
-  html = "<div class='data'><a target='_buglist' href='" + searchUrl + "'>" + totalBugs + "</a><div class='data sub'>B</div></div>";
+  html = "<div class='data'><a target='_buglist' href='" + searchUrl + "'>" + totalBugs + "</a><div class='data sub'><abbr title=\"Bug(s) in Bugzilla with no `Severity` set\">B</abbr></div></div>";
   $("#" + divId + divIndex).replaceWith(html);
 }
 
@@ -353,7 +353,7 @@ function updateBotList(divId, divIndex, totalBugs, searchUrl) {
   }
 
   $("#ubdata" + divIndex).replaceWith("<div class='ubdata'><a target='_buglist' href=\"" + searchUrl
-                                  + "\">" + totalBugs + "</a><div class='updata sub'>UB</div></div>" );
+                                  + "\">" + totalBugs + "</a><div class='updata sub'><abbr title=\"UpdateBot bug(s) in Bugzilla with no `Severity` set\">UB</abbr></div></div>" );
 }
 
 // displayType: future, current, past


### PR DESCRIPTION
Before (N.B. the beam cursor shape):

![image](https://github.com/mozilla/media-triage/assets/658538/5e86caa4-5363-42ab-b11c-109f2578d0e2)

After (N.B. the dotted underline):

![image](https://github.com/mozilla/media-triage/assets/658538/0ff5f6cd-9075-4c14-9c1a-9ff774e7b59d)

After (tooltip displaying via `title` attr.):

![image](https://github.com/mozilla/media-triage/assets/658538/b92cdfeb-2811-4690-abda-9bf5d3c095e5)
